### PR TITLE
avoid intermediate gzip files

### DIFF
--- a/git-sym.makefile
+++ b/git-sym.makefile
@@ -16,16 +16,13 @@ lambda-creads.1.fasta:
 lambda-hgap-3.creads.fasta:
 	cp -f /lustre/hpcprod/cdunn/data/lambda/hgap-3.corrected.fasta $@
 synth0.pb.fasta:
-	wget https://www.dropbox.com/s/a80t8ll29gvt883/cx.pb.fasta.gz
-	gunzip -c cx.pb.fasta.gz >| $@
+	wget https://www.dropbox.com/s/a80t8ll29gvt883/cx.pb.fasta.gz | zcat > $@
 	#cp -f /lustre/hpcprod/cdunn/data/synth0/cx.pb.fasta $@
 synth0-circ-20.pb.fasta:
-	wget https://www.dropbox.com/s/bjhcvp05u46o2qy/circ-20.pb.fasta.gz
-	gunzip -c circ-20.pb.fasta.gz >| $@
+	wget -O - https://www.dropbox.com/s/bjhcvp05u46o2qy/circ-20.pb.fasta.gz | zcat > $@
 	#cp -f /lustre/hpcprod/cdunn/data/synth0/circ-20.pb.fasta $@
 synth0.ref.fasta:
-	wget https://www.dropbox.com/s/jz0m0n2a1b19xyd/from.fasta.gz
-	gunzip -c from.fasta.gz >| $@
+	wget -O - https://www.dropbox.com/s/jz0m0n2a1b19xyd/from.fasta.gz | zcat > $@
 	#cp -f /lustre/hpcprod/cdunn/data/synth0/from.fasta $@
 arab-creads.fasta:
 	cp -f /lustre/hpcprod/cdunn/data/arab_test/corrected.fasta $@

--- a/git-sym.makefile
+++ b/git-sym.makefile
@@ -16,7 +16,7 @@ lambda-creads.1.fasta:
 lambda-hgap-3.creads.fasta:
 	cp -f /lustre/hpcprod/cdunn/data/lambda/hgap-3.corrected.fasta $@
 synth0.pb.fasta:
-	wget https://www.dropbox.com/s/a80t8ll29gvt883/cx.pb.fasta.gz | zcat > $@
+	wget -O - https://www.dropbox.com/s/a80t8ll29gvt883/cx.pb.fasta.gz | zcat > $@
 	#cp -f /lustre/hpcprod/cdunn/data/synth0/cx.pb.fasta $@
 synth0-circ-20.pb.fasta:
 	wget -O - https://www.dropbox.com/s/bjhcvp05u46o2qy/circ-20.pb.fasta.gz | zcat > $@


### PR DESCRIPTION
fixes a problem with dropbox urls that seem to be redirecting, so the filenames get changed causing missing files

Tests are still not working well in my hands (symlinks are in the wrong places), but this a step forward.

remaining problems...

```
[ERROR] Contents of '/mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/prepare_rdb.sh.log':
trap 'touch /mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/rdb_build_done.exit' EXIT
+ trap 'touch /mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/rdb_build_done.exit' EXIT
cd /mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads
+ cd /mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads
hostname
+ hostname
login-0-1.local
date
+ date
Mon Mar  7 20:55:56 EST 2016
fasta2DB -v raw_reads -f/mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/input.fofn
+ fasta2DB -v raw_reads -f/mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/input.fofn
Skipping '/mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/data/synth0.fasta', file is empty!
Updating block partition ...
LB=$(cat raw_reads.db | awk '$1 == "blocks" {print $3}')
cat raw_reads.db | awk '$1 == "blocks" {print $3}')
cat raw_reads.db | awk '$1 == "blocks" {print $3}'
++ awk '$1 == "blocks" {print $3}'
+ LB=-4
HPCdaligner -v -dal4 -t16 -h1 -e.70 -l1 -s1000 -H1 raw_reads -3-$LB > /mnt/home/langhorst/src/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/run_jobs.sh
+ HPCdaligner -v -dal4 -t16 -h1 -e.70 -l1 -s1000 -H1 raw_reads -3--4
HPCdaligner: -3 is an illegal option
```
