### PR TITLE
add quiver section to fc_unzip.cfg

### DIFF
--- a/run/greg200k-sv2/fc_unzip.cfg
+++ b/run/greg200k-sv2/fc_unzip.cfg
@@ -1,7 +1,6 @@
 [General]
 max_n_open_files = 1000
 
-
 [Unzip]
 
 input_fofn= input.fofn
@@ -20,7 +19,7 @@ input_bam_fofn= input_bam.fofn
 [job.defaults]
 NPROC=4
 njobs=7
-job_type = SGE
+#job_type = SGE
 job_type = local
 
 #use_tmpdir = /scratch
@@ -51,3 +50,7 @@ NPROC=2
 [job.step.unzip.hasm]
 njobs=1
 NPROC=48
+[job.step.unzip.quiver]
+njobs=2
+NPROC=12
+


### PR DESCRIPTION
fc_unzip.cfg packaged with test case dataset is missing `[jobs.step.unzip.quiver]` section - causing errors on certain systems when too many resources are requested